### PR TITLE
fix: encode content source maps based on them being shipped in extensions

### DIFF
--- a/lib/contentSourceMaps.ts
+++ b/lib/contentSourceMaps.ts
@@ -1,14 +1,12 @@
 import 'server-only';
 
-import { draftMode } from 'next/headers';
-
 import { encodeGraphQLResponse } from '@contentful/content-source-maps';
 import { OperationResult } from 'urql';
 
 export const isContentSourceMapsEnabled = process?.env?.CONTENTFUL_USE_CONTENT_SOURCE_MAPS === 'true';
 
 export const addContentSourceMaps = <T extends OperationResult>(response: T): T => {
-  return draftMode() && isContentSourceMapsEnabled
+  return response?.extensions && isContentSourceMapsEnabled
     ? (encodeGraphQLResponse({
         data: response.data,
         extensions: response.extensions,


### PR DESCRIPTION
Fixes the issue where during a build and prefetch on Vercel, Content source maps are not available resulting in:
> GraphQL response does not contain Content Source Maps information. { data: { pageCollection: { items: [Array] } }, extensions: undefined }

draftMode() is always true, I should have checked for `isEnabled` prop in return object 